### PR TITLE
fix: move pnpm overrides to workspace config

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,14 +38,5 @@
     "vite": "^8.0.16",
     "vitest": "^4.1.5"
   },
-  "packageManager": "pnpm@10.23.0",
-  "pnpm": {
-    "overrides": {
-      "body-parser": "2.2.1",
-      "esbuild": "0.28.1",
-      "ip-address": "10.1.1",
-      "qs": "6.15.2",
-      "vite": "8.0.16"
-    }
-  }
+  "packageManager": "pnpm@10.23.0"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,10 @@ packages:
   - "."
   - "packages/*"
   - "sdk/*"
+
+overrides:
+  body-parser: 2.2.1
+  esbuild: 0.28.1
+  ip-address: 10.1.1
+  qs: 6.15.2
+  vite: 8.0.16


### PR DESCRIPTION
## Summary
- move existing pnpm overrides from the ignored package.json pnpm block into pnpm-workspace.yaml
- keep the existing security/remediation override versions unchanged
- leave pnpm-lock.yaml unchanged because it already records the same overrides

## Validation
- npx --yes pnpm@10.23.0 install --frozen-lockfile
- npx --yes pnpm@10.23.0 check

## Notes
- pnpm no longer warns that package.json pnpm.overrides is ignored after this move.