### PR TITLE
fix(cli): redact sessionKey from starter CLI JSON output

### DIFF
--- a/sdk/coding-agent-cli/README.md
+++ b/sdk/coding-agent-cli/README.md
@@ -34,3 +34,6 @@ Cancellation requested during startup waits for the run handle. If cancellation
 fails, the CLI reports the error and stays available for another `/cancel` or
 `/exit`. Ctrl+C cancels while a run is active and exits when idle. Closing input
 also attempts cancellation before closing the SDK client.
+
+Structured JSON output masks session keys and credential-like fields, matching the
+cookbook recipes. Streamed assistant text remains verbatim.

--- a/sdk/coding-agent-cli/src/index.ts
+++ b/sdk/coding-agent-cli/src/index.ts
@@ -3,6 +3,7 @@ import { createInterface } from "node:readline";
 import { stdin as defaultInput, stdout as defaultOutput } from "node:process";
 import { pathToFileURL } from "node:url";
 import { OpenClaw, type Run } from "@openclaw/sdk";
+import { redactSensitiveOutput } from "./redact-sensitive-output.js";
 
 type CliState = {
   agentId: string;
@@ -67,7 +68,7 @@ export async function runCodingAgentCli(options: CodingAgentCliOptions = {}): Pr
       // Await the handle so cancellation requested during startup is retained.
       cancellation = (async () => {
         const run = await created;
-        output.write(`${JSON.stringify(await run.cancel(), null, 2)}\n`);
+        output.write(`${JSON.stringify(redactSensitiveOutput(await run.cancel()), null, 2)}\n`);
         return true;
       })().catch((error: unknown) => {
         if (runCreated === created) cancellation = null;
@@ -109,7 +110,7 @@ export async function runCodingAgentCli(options: CodingAgentCliOptions = {}): Pr
         }
       }
       const result = await run.wait({ timeoutMs: 120_000 });
-      output.write(`\n${JSON.stringify(result, null, 2)}\n`);
+      output.write(`\n${JSON.stringify(redactSensitiveOutput(result), null, 2)}\n`);
     } finally {
       runCreated = null;
       cancellation = null;
@@ -131,7 +132,9 @@ export async function runCodingAgentCli(options: CodingAgentCliOptions = {}): Pr
         output.write(`session=${state.sessionKey}\n`);
         return true;
       case "/status":
-        output.write(`${JSON.stringify(await oc.models.status({ probe: false }), null, 2)}\n`);
+        output.write(
+          `${JSON.stringify(redactSensitiveOutput(await oc.models.status({ probe: false })), null, 2)}\n`,
+        );
         return true;
       case "/cancel":
         await cancelActiveRun();

--- a/sdk/coding-agent-cli/src/redact-sensitive-output.ts
+++ b/sdk/coding-agent-cli/src/redact-sensitive-output.ts
@@ -1,0 +1,30 @@
+// Keep in sync with recipes/_shared/run-main.ts so this example stays standalone.
+export function redactSensitiveOutput(value: unknown, seen = new WeakSet<object>()): unknown {
+  if (Array.isArray(value)) {
+    return value.map((entry) => redactSensitiveOutput(entry, seen));
+  }
+  if (value && typeof value === "object") {
+    if (seen.has(value)) {
+      return "[Circular]";
+    }
+    seen.add(value);
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [
+        key,
+        isSensitiveKey(key) ? "[REDACTED]" : redactSensitiveOutput(entry, seen),
+      ]),
+    );
+  }
+  return value;
+}
+
+function isSensitiveKey(key: string): boolean {
+  const normalized = key.toLowerCase();
+  return (
+    normalized.includes("token") ||
+    normalized.includes("password") ||
+    normalized.includes("secret") ||
+    normalized.includes("authorization") ||
+    normalized.endsWith("key")
+  );
+}

--- a/sdk/quickstart/README.md
+++ b/sdk/quickstart/README.md
@@ -24,3 +24,6 @@ pnpm start
 
 Set `OPENCLAW_AGENT_ID`, `OPENCLAW_SESSION_KEY`, or `OPENCLAW_MODEL` to override
 the defaults.
+
+Structured JSON output masks session keys and credential-like fields, matching the
+cookbook recipes. Streamed assistant text remains verbatim.

--- a/sdk/quickstart/src/index.ts
+++ b/sdk/quickstart/src/index.ts
@@ -1,4 +1,5 @@
 import { OpenClaw } from "@openclaw/sdk";
+import { redactSensitiveOutput } from "./redact-sensitive-output.js";
 
 const oc = new OpenClaw({
   gateway: process.env.OPENCLAW_GATEWAY ?? "auto",
@@ -38,7 +39,7 @@ try {
   }
 
   const result = await run.wait({ timeoutMs: 120_000 });
-  process.stdout.write(`\n\n${JSON.stringify(result, null, 2)}\n`);
+  process.stdout.write(`\n\n${JSON.stringify(redactSensitiveOutput(result), null, 2)}\n`);
 } finally {
   await oc.close();
 }

--- a/sdk/quickstart/src/redact-sensitive-output.ts
+++ b/sdk/quickstart/src/redact-sensitive-output.ts
@@ -1,0 +1,30 @@
+// Keep in sync with recipes/_shared/run-main.ts so this example stays standalone.
+export function redactSensitiveOutput(value: unknown, seen = new WeakSet<object>()): unknown {
+  if (Array.isArray(value)) {
+    return value.map((entry) => redactSensitiveOutput(entry, seen));
+  }
+  if (value && typeof value === "object") {
+    if (seen.has(value)) {
+      return "[Circular]";
+    }
+    seen.add(value);
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [
+        key,
+        isSensitiveKey(key) ? "[REDACTED]" : redactSensitiveOutput(entry, seen),
+      ]),
+    );
+  }
+  return value;
+}
+
+function isSensitiveKey(key: string): boolean {
+  const normalized = key.toLowerCase();
+  return (
+    normalized.includes("token") ||
+    normalized.includes("password") ||
+    normalized.includes("secret") ||
+    normalized.includes("authorization") ||
+    normalized.endsWith("key")
+  );
+}

--- a/test/sdk-starter-cli-redact.test.ts
+++ b/test/sdk-starter-cli-redact.test.ts
@@ -1,0 +1,61 @@
+import { execFile } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+import { redactSensitiveOutput } from "../recipes/_shared/run-main.js";
+import { redactSensitiveOutput as codingAgentRedact } from "../sdk/coding-agent-cli/src/redact-sensitive-output.js";
+import { redactSensitiveOutput as quickstartRedact } from "../sdk/quickstart/src/redact-sensitive-output.js";
+
+const execFileAsync = promisify(execFile);
+const repoRoot = fileURLToPath(new URL("..", import.meta.url));
+const LEAKED_SESSION_KEY = "leaked-session-key-f002";
+
+async function runStarter(filter: string, args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync(
+    "pnpm",
+    ["--filter", filter, "exec", "tsx", "src/index.ts", ...args],
+    {
+      cwd: repoRoot,
+      env: { ...process.env, OPENCLAW_SESSION_KEY: LEAKED_SESSION_KEY },
+      timeout: 20_000,
+    },
+  );
+  return stdout;
+}
+
+const SAMPLE = {
+  sessionKey: "cookbook-demo",
+  nested: { token: "abc123", password: "s3cret", authorization: "Bearer x", ok: true },
+  raw: { apiKey: "sk-live", count: 1 },
+};
+
+describe("SDK starter CLI JSON output", () => {
+  it("keeps starter helpers aligned with the recipe redactor", () => {
+    expect(codingAgentRedact(SAMPLE)).toEqual(redactSensitiveOutput(SAMPLE));
+    expect(quickstartRedact(SAMPLE)).toEqual(redactSensitiveOutput(SAMPLE));
+    expect(codingAgentRedact(SAMPLE)).toEqual({
+      sessionKey: "[REDACTED]",
+      nested: {
+        token: "[REDACTED]",
+        password: "[REDACTED]",
+        authorization: "[REDACTED]",
+        ok: true,
+      },
+      raw: { apiKey: "[REDACTED]", count: 1 },
+    });
+  });
+
+  it("redacts sessionKey from coding-agent-cli run JSON", async () => {
+    const stdout = await runStarter("@openclaw/cookbook-coding-agent-cli", ["Cookbook smoke"]);
+
+    expect(stdout).toMatch(/"sessionKey": "\[REDACTED\]"/);
+    expect(stdout).not.toContain(LEAKED_SESSION_KEY);
+  });
+
+  it("redacts sessionKey from quickstart run JSON", async () => {
+    const stdout = await runStarter("@openclaw/cookbook-quickstart", ["Cookbook smoke"]);
+
+    expect(stdout).toMatch(/"sessionKey": "\[REDACTED\]"/);
+    expect(stdout).not.toContain(LEAKED_SESSION_KEY);
+  });
+});


### PR DESCRIPTION
The standalone CLI starters now apply the cookbook's established redaction policy to result, status, and cancellation JSON. Local helpers keep the examples independently copyable; assistant text remains verbatim.

Independently rebased onto main at `6deea84fc44138676bdf0d4b99dae98ec33d43ff`. The CLI source and README exactly match the previously proven combined resolution with the already-landed #7 lifecycle. This PR has no changelog changes; #12 owns the complete Unreleased section. Contributor credit is preserved in the commit.

Previous live compiled-CLI proof for the same output behavior: https://github.com/openclaw/cookbook/pull/8#issuecomment-5554448024
