### PR TITLE
fix(workbench): redact sensitive fields in run result JSON

### DIFF
--- a/sdk/agent-workbench/README.md
+++ b/sdk/agent-workbench/README.md
@@ -21,3 +21,7 @@ pnpm dev
 Open the Vite URL and run the demo. The cookbook shim makes the app work during
 local CI; once `@openclaw/sdk` is published, the same UI can point at a real
 Gateway.
+
+The Result panel masks session keys and credential-like fields in structured JSON.
+Session controls and streamed assistant text remain visible, so this does not
+sanitize an entire screenshot or recording.

--- a/sdk/agent-workbench/src/App.tsx
+++ b/sdk/agent-workbench/src/App.tsx
@@ -13,6 +13,7 @@ import {
   Workflow,
 } from "lucide-react";
 import { OpenClaw, type OpenClawEvent, type RunResult } from "@openclaw/sdk";
+import { formatRunResultJson } from "./format-run-result-json.js";
 
 type EventRow = Pick<OpenClawEvent, "type" | "runId" | "ts"> & {
   text?: string;
@@ -282,7 +283,7 @@ export function App() {
               {result?.status ?? "pending"}
             </small>
           </div>
-          <pre>{result ? JSON.stringify(result, null, 2) : "No result yet."}</pre>
+          <pre>{result ? formatRunResultJson(result) : "No result yet."}</pre>
         </section>
       </section>
     </main>

--- a/sdk/agent-workbench/src/format-run-result-json.ts
+++ b/sdk/agent-workbench/src/format-run-result-json.ts
@@ -1,0 +1,5 @@
+import { redactSensitiveOutput } from "./redact-sensitive-output.js";
+
+export function formatRunResultJson(result: unknown): string {
+  return JSON.stringify(redactSensitiveOutput(result), null, 2);
+}

--- a/sdk/agent-workbench/src/redact-sensitive-output.ts
+++ b/sdk/agent-workbench/src/redact-sensitive-output.ts
@@ -1,0 +1,30 @@
+// Keep in sync with recipes/_shared/run-main.ts so this example stays standalone.
+export function redactSensitiveOutput(value: unknown, seen = new WeakSet<object>()): unknown {
+  if (Array.isArray(value)) {
+    return value.map((entry) => redactSensitiveOutput(entry, seen));
+  }
+  if (value && typeof value === "object") {
+    if (seen.has(value)) {
+      return "[Circular]";
+    }
+    seen.add(value);
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [
+        key,
+        isSensitiveKey(key) ? "[REDACTED]" : redactSensitiveOutput(entry, seen),
+      ]),
+    );
+  }
+  return value;
+}
+
+function isSensitiveKey(key: string): boolean {
+  const normalized = key.toLowerCase();
+  return (
+    normalized.includes("token") ||
+    normalized.includes("password") ||
+    normalized.includes("secret") ||
+    normalized.includes("authorization") ||
+    normalized.endsWith("key")
+  );
+}

--- a/test/workbench-redact.test.ts
+++ b/test/workbench-redact.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { OpenClaw } from "@openclaw/sdk";
+import { redactSensitiveOutput } from "../recipes/_shared/run-main.js";
+import { formatRunResultJson } from "../sdk/agent-workbench/src/format-run-result-json.js";
+import { redactSensitiveOutput as workbenchRedact } from "../sdk/agent-workbench/src/redact-sensitive-output.js";
+
+const LEAKED_SESSION_KEY = "leaked-session-key-f003";
+const LEAKED_TOKEN = "tok-live-f003";
+const LEAKED_PASSWORD = "p@ss-f003";
+
+const SAMPLE = {
+  runId: "run_workbench",
+  status: "completed",
+  sessionKey: LEAKED_SESSION_KEY,
+  token: LEAKED_TOKEN,
+  password: LEAKED_PASSWORD,
+  raw: { apiKey: "sk-live-f003", count: 1 },
+};
+
+describe("agent workbench result JSON", () => {
+  it("keeps the workbench helper aligned with the recipe redactor", () => {
+    expect(workbenchRedact(SAMPLE)).toEqual(redactSensitiveOutput(SAMPLE));
+  });
+
+  it("omits sessionKey, token, and password from rendered result JSON", () => {
+    const json = formatRunResultJson(SAMPLE);
+
+    expect(json).toMatch(/"sessionKey": "\[REDACTED\]"/);
+    expect(json).toMatch(/"token": "\[REDACTED\]"/);
+    expect(json).toMatch(/"password": "\[REDACTED\]"/);
+    expect(json).not.toContain(LEAKED_SESSION_KEY);
+    expect(json).not.toContain(LEAKED_TOKEN);
+    expect(json).not.toContain(LEAKED_PASSWORD);
+    expect(json).not.toContain("sk-live-f003");
+  });
+
+  it("redacts sessionKey from a workbench wait() result", async () => {
+    const oc = new OpenClaw();
+    const run = await oc.runs.create({
+      input: "Cookbook smoke",
+      sessionKey: LEAKED_SESSION_KEY,
+    });
+    for await (const event of run.events()) {
+      if (
+        event.type === "run.completed" ||
+        event.type === "run.failed" ||
+        event.type === "run.cancelled" ||
+        event.type === "run.timed_out"
+      ) {
+        break;
+      }
+    }
+    const json = formatRunResultJson(await run.wait());
+    await oc.close();
+
+    expect(json).toMatch(/"sessionKey": "\[REDACTED\]"/);
+    expect(json).not.toContain(LEAKED_SESSION_KEY);
+  });
+});


### PR DESCRIPTION
Agent Workbench masks sensitive fields at the Result display boundary without changing session settings, SDK requests, or streamed assistant text. The helper stays local to preserve the copyable browser example.

Independently rebased onto main at `6deea84fc44138676bdf0d4b99dae98ec33d43ff`. This PR has no changelog changes; #12 owns the complete Unreleased section. Contributor credit is preserved in the commit.

Before/after real-Chrome evidence for the unchanged renderer patch: https://github.com/openclaw/cookbook/pull/10#issuecomment-5554445494
