### PR TITLE
fix(workbench): redact sensitive fields in run result JSON

### DIFF
--- a/sdk/agent-workbench/README.md
+++ b/sdk/agent-workbench/README.md
@@ -21,3 +21,7 @@ pnpm dev
 Open the Vite URL and run the demo. The cookbook shim makes the app work during
 local CI; once `@openclaw/sdk` is published, the same UI can point at a real
 Gateway.
+
+The Result panel masks session keys and credential-like fields in structured JSON.
+Session controls and streamed assistant text remain visible, so this does not
+sanitize an entire screenshot or recording.

--- a/sdk/agent-workbench/README.md
+++ b/sdk/agent-workbench/README.md
@@ -22,6 +22,9 @@ Open the Vite URL and run the demo. The cookbook shim makes the app work during
 local CI; once `@openclaw/sdk` is published, the same UI can point at a real
 Gateway.
 
-The Result panel masks session keys and credential-like fields in structured JSON.
+The Result panel follows the cookbook's existing field-name redaction convention:
+JSON fields whose names contain `token`, `password`, `secret`, or `authorization`,
+or end in `key`, are masked case-insensitively. This also masks non-secret fields
+such as `tokenCount`; it does not detect secrets in other fields or inside text.
 Session controls and streamed assistant text remain visible, so this does not
 sanitize an entire screenshot or recording.

--- a/sdk/agent-workbench/src/App.tsx
+++ b/sdk/agent-workbench/src/App.tsx
@@ -13,6 +13,7 @@ import {
   Workflow,
 } from "lucide-react";
 import { OpenClaw, type OpenClawEvent, type RunResult } from "@openclaw/sdk";
+import { formatRunResultJson } from "./format-run-result-json.js";
 
 type EventRow = Pick<OpenClawEvent, "type" | "runId" | "ts"> & {
   text?: string;
@@ -282,7 +283,7 @@ export function App() {
               {result?.status ?? "pending"}
             </small>
           </div>
-          <pre>{result ? JSON.stringify(result, null, 2) : "No result yet."}</pre>
+          <pre>{result ? formatRunResultJson(result) : "No result yet."}</pre>
         </section>
       </section>
     </main>

--- a/sdk/agent-workbench/src/format-run-result-json.ts
+++ b/sdk/agent-workbench/src/format-run-result-json.ts
@@ -1,0 +1,5 @@
+import { redactSensitiveOutput } from "./redact-sensitive-output.js";
+
+export function formatRunResultJson(result: unknown): string {
+  return JSON.stringify(redactSensitiveOutput(result), null, 2);
+}

--- a/sdk/agent-workbench/src/redact-sensitive-output.ts
+++ b/sdk/agent-workbench/src/redact-sensitive-output.ts
@@ -1,0 +1,30 @@
+// Keep in sync with recipes/_shared/run-main.ts so this example stays standalone.
+export function redactSensitiveOutput(value: unknown, seen = new WeakSet<object>()): unknown {
+  if (Array.isArray(value)) {
+    return value.map((entry) => redactSensitiveOutput(entry, seen));
+  }
+  if (value && typeof value === "object") {
+    if (seen.has(value)) {
+      return "[Circular]";
+    }
+    seen.add(value);
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [
+        key,
+        isSensitiveKey(key) ? "[REDACTED]" : redactSensitiveOutput(entry, seen),
+      ]),
+    );
+  }
+  return value;
+}
+
+function isSensitiveKey(key: string): boolean {
+  const normalized = key.toLowerCase();
+  return (
+    normalized.includes("token") ||
+    normalized.includes("password") ||
+    normalized.includes("secret") ||
+    normalized.includes("authorization") ||
+    normalized.endsWith("key")
+  );
+}

--- a/test/workbench-redact.test.ts
+++ b/test/workbench-redact.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { OpenClaw } from "@openclaw/sdk";
+import { redactSensitiveOutput } from "../recipes/_shared/run-main.js";
+import { formatRunResultJson } from "../sdk/agent-workbench/src/format-run-result-json.js";
+import { redactSensitiveOutput as workbenchRedact } from "../sdk/agent-workbench/src/redact-sensitive-output.js";
+
+const LEAKED_SESSION_KEY = "leaked-session-key-f003";
+const LEAKED_TOKEN = "tok-live-f003";
+const LEAKED_PASSWORD = "p@ss-f003";
+
+const SAMPLE = {
+  runId: "run_workbench",
+  status: "completed",
+  sessionKey: LEAKED_SESSION_KEY,
+  token: LEAKED_TOKEN,
+  password: LEAKED_PASSWORD,
+  raw: { apiKey: "sk-live-f003", count: 1 },
+};
+
+describe("agent workbench result JSON", () => {
+  it("keeps the workbench helper aligned with the recipe redactor", () => {
+    expect(workbenchRedact(SAMPLE)).toEqual(redactSensitiveOutput(SAMPLE));
+  });
+
+  it("omits sessionKey, token, and password from rendered result JSON", () => {
+    const json = formatRunResultJson(SAMPLE);
+
+    expect(json).toMatch(/"sessionKey": "\[REDACTED\]"/);
+    expect(json).toMatch(/"token": "\[REDACTED\]"/);
+    expect(json).toMatch(/"password": "\[REDACTED\]"/);
+    expect(json).not.toContain(LEAKED_SESSION_KEY);
+    expect(json).not.toContain(LEAKED_TOKEN);
+    expect(json).not.toContain(LEAKED_PASSWORD);
+    expect(json).not.toContain("sk-live-f003");
+  });
+
+  it("redacts sessionKey from a workbench wait() result", async () => {
+    const oc = new OpenClaw();
+    const run = await oc.runs.create({
+      input: "Cookbook smoke",
+      sessionKey: LEAKED_SESSION_KEY,
+    });
+    for await (const event of run.events()) {
+      if (
+        event.type === "run.completed" ||
+        event.type === "run.failed" ||
+        event.type === "run.cancelled" ||
+        event.type === "run.timed_out"
+      ) {
+        break;
+      }
+    }
+    const json = formatRunResultJson(await run.wait());
+    await oc.close();
+
+    expect(json).toMatch(/"sessionKey": "\[REDACTED\]"/);
+    expect(json).not.toContain(LEAKED_SESSION_KEY);
+  });
+});


### PR DESCRIPTION
Agent Workbench renders the raw `run.wait()` result, exposing the session key in its Result JSON. Apply the cookbook's existing field-name redaction convention at the Result display boundary, matching recipes and the standalone CLIs.

The helper remains local so this browser starter stays independently copyable without importing Node-only recipe code. SDK state, session controls, and assistant text keep their existing behavior. The README explicitly describes the name-based matching, its overmasking, and its limits; this does not sanitize an entire page or recording.

This restores the fix from closed, unmerged #10 on current main. The cause of that earlier closure is unconfirmed. The implementation and regression tests are by @SebTardif; the maintainer clarified the documentation and captured fresh browser proof.

## Validation

- `pnpm check`: formatting, types, lint, all 23 tests, documentation for six recipes, all four starter builds, and both compiled CLI smokes pass.
- Real Chrome on macOS, Node 24.20.0, pnpm 10.34.5, and the documented local workspace SDK shim: build the baseline and PR, serve using Vite preview, fill a synthetic session and prompt, then click Run. Baseline Result exposes the synthetic session; the PR shows `[REDACTED]`. Both complete with three events and `hello from OpenClaw`.
- `pnpm audit --json`: zero vulnerabilities. Independent autoreview through P2 is clean; final head `8ab8dc14823d2da5b6a563252a56e3ddee6c12db` passed [Check](https://github.com/openclaw/cookbook/actions/runs/34180923631). [Maintainer proof](https://github.com/openclaw/cookbook/pull/13#issuecomment-5578303268) includes the final-head browser rerun after the documentation clarification.
- No live Gateway/provider behavior is claimed.

The changelog entry is in the separate final notes PR #14, to merge after this one. Merge and first-release decisions remain with the maintainer.

![Before: baseline Result exposes the synthetic session](https://github.com/user-attachments/assets/b429af49-619f-49ba-9468-6fe28dbc177d)

![After: PR 13 Result redacts the synthetic session](https://github.com/user-attachments/assets/9b568925-3d52-46fc-bcbe-8fb88b52483e)
