### PR TITLE
docs: record workbench result redaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,13 @@
 
 ## Unreleased
 
-**Highlights:** Six runnable SDK recipes and four copyable starter apps, with responsive terminal cancellation and sensitive-field redaction in CLI JSON output.
+**Highlights:** Six runnable SDK recipes and four copyable starter apps, with responsive terminal cancellation and sensitive-field redaction in CLI and Workbench Result JSON output.
 
 - Add standalone Quickstart, Coding Agent CLI, Agent Workbench, and Run Board examples for terminal apps, agent control, and run monitoring.
 - Add focused recipes for starting runs, streaming events, cancelling work, reusing sessions, checking models, and using an in-memory transport.
 - Keep the coding-agent CLI responsive for cancellation, including startup, retry, terminal shutdown, and symlinked entrypoints; thanks @SebTardif.
 - Redact sensitive fields from Quickstart and Coding Agent CLI result, status, and cancellation JSON; thanks @SebTardif.
+- Apply the cookbook field-name redaction convention to Agent Workbench Result JSON while preserving session controls and assistant text; thanks @SebTardif.
 - Redact credential-like fields from recipe and Node CLI wrapper output.
 - Build the workspace SDK shim so compiled standalone examples run locally before the SDK package is published.
 - Add a Node CLI recipe wrapper, recipe manifests, contribution guidance, and checks for documentation and all starter examples.


### PR DESCRIPTION
Record Agent Workbench Result redaction alongside the existing unreleased cookbook changes, with contributor credit for @SebTardif. The Highlights line now covers the browser Result panel as well as CLI output.

Merge after #13. This branch is independent of #13 and changes only CHANGELOG.md; the contributor PR carries code, tests, and its README.

Validation: the full cookbook gate passes on this independent branch (20 tests, all four starter builds, and both compiled CLI smokes). Local candidate autoreview through P2 is clean. PR #13 separately adds three regression tests and has real Chrome before/after proof: https://github.com/openclaw/cookbook/pull/13#issuecomment-5578303268.

Dependency check: no compatible patch/minor update is pending, the current GitHub Action major refs cover their latest releases, and pnpm audit reports zero vulnerabilities. Vitest 5 tightens the supported Node range; the previously held pnpm major migration remains separate.

This prepares release notes only. There is still no prior release tag; first-release approval remains separate.
